### PR TITLE
Streaming links

### DIFF
--- a/_includes/header.html
+++ b/_includes/header.html
@@ -77,7 +77,7 @@
 						<ul>
 							<li><a class="sub-menu-" href="/general-instructions">General</a></li>
 							<li><a class="sub-menu-" href="/gather">Gather Town</a></li>
-							<li><a class="sub-menu-" href="#" onclick="gostreams()">Live Streams</a></li>
+							<li><a class="sub-menu-" href="/live-streams">Live Streams</a></li>
 							<li><a class="sub-menu-" href="/zoom-meetings">Zoom</a></li>
 						</ul>
 					</li>
@@ -89,10 +89,3 @@
 		</div>
 	</div>
 </header>
-
-<script>
-	function gostreams() {
-	  let pwd = prompt("Please enter the password");
-	  window.location.href = "live-streams-" + pwd;
-	}
-</script>

--- a/_posts/2022-06-08-gather.html
+++ b/_posts/2022-06-08-gather.html
@@ -13,7 +13,7 @@ permalink: gather
         <ul class="link-list">
           <li><a href="/general-instructions">General</a></li>
           <li><a href="/gather">Gather Town</a></li>
-          <li><a href="#" onclick="gostreams()">Live Streams</a></li>
+          <li><a href="/live-streams">Live Streams</a></li>
           <li><a href="/zoom-meetings">Zoom</a></li>
         </ul>
       </section>
@@ -24,8 +24,6 @@ permalink: gather
 
 
     <div class="9u 12u(mobile)">
-
-      <div id="disaward"></div>
 
       <section>
         <div class="row">

--- a/_posts/2022-06-08-general-instructions.html
+++ b/_posts/2022-06-08-general-instructions.html
@@ -13,7 +13,7 @@ permalink: general-instructions
         <ul class="link-list">
           <li><a href="/general-instructions">General</a></li>
           <li><a href="/gather">Gather Town</a></li>
-          <li><a href="#" onclick="gostreams()">Live Streams</a></li>
+          <li><a href="/live-streams">Live Streams</a></li>
           <li><a href="/zoom-meetings">Zoom</a></li>
         </ul>
       </section>
@@ -24,8 +24,6 @@ permalink: general-instructions
 
 
     <div class="9u 12u(mobile)">
-
-      <div id="disaward"></div>
 
       <section>
         <div class="row">
@@ -39,7 +37,7 @@ permalink: general-instructions
 
               <li><strong>Via gather.town (preferred):</strong> You can enter the ICAPS 2022 gather.town virtual conference space using
                 this link:<br>
-                <a href="https://app.gather.town/app/HZHd6ck9wn1jzaFJ/ICAPS22">https://app.gather.town/app/HZHd6ck9wn1jzaFJ/ICAPS22</a>
+                <a href="https://app.gather.town/app/HZHd6ck9wn1jzaFJ/ICAPS22" target="_blank">https://app.gather.town/app/HZHd6ck9wn1jzaFJ/ICAPS22</a>
 
                 <p>All events will be accessible from within the virtual space.
                 Meet your fellows in the gather.town space and interact with other attendants in the virtual space!
@@ -51,7 +49,7 @@ permalink: general-instructions
                 <p>In the Zoom sessions, you can ask questions directly to the presenters, preferably via audio/video,
                 alternatively via text chat.</p></li>
 
-              <li><strong>Watching live streams on <a href="#" onclick="gostreams()">this webpage</a> (password protected).</strong>
+              <li><strong>Watching live streams on <a href="/live-streams">this webpage</a>.</strong>
 
                 <p>All technical and plenary sessions can be watched using these streams.
                 However, no interaction will be possible with other attendants.

--- a/_posts/2022-06-08-live-streams.html
+++ b/_posts/2022-06-08-live-streams.html
@@ -1,7 +1,7 @@
 ---
 title: ICAPS 2022 Live Streams
 layout: page
-permalink: live-streams-icaps22sin
+permalink: live-streams
 ---
 <div class="container">
   <div class="row">
@@ -13,7 +13,7 @@ permalink: live-streams-icaps22sin
         <ul class="link-list">
           <li><a href="/general-instructions">General</a></li>
           <li><a href="/gather">Gather Town</a></li>
-          <li><a href="#" onclick="gostreams()">Live Streams</a></li>
+          <li><a href="/live-streams">Live Streams</a></li>
           <li><a href="/zoom-meetings">Zoom</a></li>
         </ul>
       </section>
@@ -21,11 +21,7 @@ permalink: live-streams-icaps22sin
 
 
 
-
-
     <div class="9u 12u(mobile)">
-
-      <div id="disaward"></div>
 
       <section>
         <div class="row">
@@ -39,6 +35,9 @@ permalink: live-streams-icaps22sin
             <p>Note that you will not be able to interact with other attendants when following the conference using the
               web-streams.</p>
 
+            <h3>Password</h3>
+            <p>You will be prompted to enter a password to access the online streams. This password has been sent to you via
+              email.</p>
 
             <h3>Track A / Plenary sessions</h3>
             <p>Link will be published here soon.</p>

--- a/_posts/2022-06-08-zoom-meetings.html
+++ b/_posts/2022-06-08-zoom-meetings.html
@@ -13,7 +13,7 @@ permalink: zoom-meetings
         <ul class="link-list">
           <li><a href="/general-instructions">General</a></li>
           <li><a href="/gather">Gather Town</a></li>
-          <li><a href="#" onclick="gostreams()">Live Streams</a></li>
+          <li><a href="/live-streams">Live Streams</a></li>
           <li><a href="/zoom-meetings">Zoom</a></li>
         </ul>
       </section>
@@ -24,8 +24,6 @@ permalink: zoom-meetings
 
 
     <div class="9u 12u(mobile)">
-
-      <div id="disaward"></div>
 
       <section>
         <div class="row">

--- a/_posts/2022-06-17-live-stream.html
+++ b/_posts/2022-06-17-live-stream.html
@@ -1,0 +1,30 @@
+---
+title: ICAPS 2022 Main Conference Live Stream
+layout: page
+permalink: live-stream
+---
+<div class="container">
+  <div class="row">
+
+    <div class="12u 12u(mobile)">
+
+      <section>
+
+        <h1>Live Stream for Day 1 - June 21 - Track A and Plenary sessions</h1>
+
+        <div id="presentation-embed-38984519"></div>
+        <script src="https://slideslive.com/embed_presentation.js"></script>
+        <script>
+          embed = new SlidesLiveEmbed("presentation-embed-38984519", {
+            presentationId: "38984519",
+            autoPlay: false,
+            verticalEnabled: true,
+          });
+        </script>
+
+      </section>
+
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Please see my email for more detailed info. 
There will be 8 streaming links in total, two for each of the main conference days. I think it might be a bit convoluted to put 8 video players on a single webpage. A separate page per stream might be nicer. I added one such sample page, not linked to from any other page, yet. 
How should we proceed from here? I can simply create 7 more static pages for each of the missing streams if you like. If you have a nicer solution, I'd be happy to go for that. As you prefer!

I also removed the password protection for the live-streams page. Can you please double-check that I didn't forget anything.