### PR TITLE
add id of public video

### DIFF
--- a/_posts/2022-06-17-live-stream.html
+++ b/_posts/2022-06-17-live-stream.html
@@ -12,11 +12,11 @@ permalink: live-stream
 
         <h1>Live Stream for Day 1 - June 21 - Track A and Plenary sessions</h1>
 
-        <div id="presentation-embed-38984519"></div>
+        <div id="presentation-embed-38982809"></div>
         <script src="https://slideslive.com/embed_presentation.js"></script>
         <script>
-          embed = new SlidesLiveEmbed("presentation-embed-38984519", {
-            presentationId: "38984519",
+          embed = new SlidesLiveEmbed("presentation-embed-38982809", {
+            presentationId: "38982809",
             autoPlay: false,
             verticalEnabled: true,
           });


### PR DESCRIPTION
Couldn't find a way to reopen the merged PR.
Here is a video ID that should be publicly available.